### PR TITLE
Fixes deprecated key warning when running tests

### DIFF
--- a/tests/TestCase/Model/Behavior/SequenceBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SequenceBehaviorTest.php
@@ -200,7 +200,7 @@ class SequenceTest extends TestCase
 
         $query = $query ?: $table->find();
 
-        $records = $query->find('list', ['idField' => $order, 'valueField' => 'id'])
+        $records = $query->find('list', ['keyField' => $order, 'valueField' => 'id'])
             ->where($conditions)
             ->order([$order => 'ASC'])
             ->toArray();


### PR DESCRIPTION
Fixes the `Option "idField" is deprecated, use "keyField" instead.` warning when running tests