### PR TITLE
disregard virtual fields when checking old value

### DIFF
--- a/src/Model/Behavior/SequenceBehavior.php
+++ b/src/Model/Behavior/SequenceBehavior.php
@@ -342,19 +342,22 @@ class SequenceBehavior extends Behavior
 
         if (count($fields) != count($values)) {
             $primaryKey = $entity->get($this->_table->primaryKey());
-            $values = $this->_table->get(
+            $entity = $this->_table->get(
                 $primaryKey,
                 [
                     'fields' => $fields,
                     'limit' => 1,
                 ]
-            )
-            ->toArray();
+            );
+            $virtuals = $entity->virtualProperties();
+            $values = $entity->toArray();
+            foreach($entity->virtualProperties() as $virtual) {
+                unset($values[$virtual]);
+            }
         }
 
         $order = $values[$config['order']];
         unset($values[$config['order']]);
-
         return [$order, $values];
     }
 

--- a/tests/TestCase/Model/Behavior/SequenceBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SequenceBehaviorTest.php
@@ -9,6 +9,11 @@ use Cake\TestSuite\TestCase;
 class Item extends Entity
 {
     protected $_accessible = ['*' => true, 'id' => false];
+    
+    protected function _getVirtualField()
+    {
+        return "dummy";
+    }    
 }
 
 class Items extends Table


### PR DESCRIPTION
I've had similar problems explained in issue #21. This pull request removes virtual fields when checking old values.