### PR TITLE
Remove unneeded apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $this->addBehavior('ADmad/Sequence.Sequence', [
 ]);
 ```
 
-Now whenever to add a new record it's `position` field will be automatically
+Now whenever to add a new record its `position` field will be automatically
 set to current largest value in sequence plus one.
 
 When editing records you can set the position to a new value and the position of


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!