### PR TITLE
Only attempt to decrement orders after delete

### DIFF
--- a/src/Model/Behavior/SequenceBehavior.php
+++ b/src/Model/Behavior/SequenceBehavior.php
@@ -235,7 +235,7 @@ class SequenceBehavior extends Behavior
      * When you delete a record from a set, you need to decrement the order of all
      * records that were after it in the set.
      *
-     * @param \Cake\Event\Event $event The afterDelete event that was fired.
+     * @param \Cake\Event\Event $event The beforeDelete event that was fired.
      * @param \Cake\ORM\Entity $entity The entity that is going to be saved.
      *
      * @return void
@@ -250,7 +250,7 @@ class SequenceBehavior extends Behavior
      * records that were after it in the set.
      *
      * @param \Cake\Event\Event $event The afterDelete event that was fired.
-     * @param \Cake\ORM\Entity $entity The entity that is going to be saved.
+     * @param \Cake\ORM\Entity $entity The entity that has been deleted.
      *
      * @return void
      */

--- a/src/Model/Behavior/SequenceBehavior.php
+++ b/src/Model/Behavior/SequenceBehavior.php
@@ -228,12 +228,12 @@ class SequenceBehavior extends Behavior
      * When you delete a record from a set, you need to decrement the order of all
      * records that were after it in the set.
      *
-     * @param \Cake\Event\Event $event The beforeDelete event that was fired.
+     * @param \Cake\Event\Event $event The afterDelete event that was fired.
      * @param \Cake\ORM\Entity $entity The entity that is going to be saved.
      *
      * @return void
      */
-    public function beforeDelete(Event $event, Entity $entity)
+    public function afterDelete(Event $event, Entity $entity)
     {
         $orderField = $this->_config['order'];
         list($order, $scope) = $this->_getOldValues($entity);

--- a/src/Model/Behavior/SequenceBehavior.php
+++ b/src/Model/Behavior/SequenceBehavior.php
@@ -257,7 +257,7 @@ class SequenceBehavior extends Behavior
     public function afterDelete(Event $event, Entity $entity)
     {
         if (!$this->_oldValues) {
-            return null;
+            return;
         }
 
         $orderField = $this->_config['order'];

--- a/tests/Fixture/UniqueItemsFixture.php
+++ b/tests/Fixture/UniqueItemsFixture.php
@@ -1,0 +1,35 @@
+<?php
+namespace ADmad\Sequence\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class UniqueItemsFixture extends TestFixture
+{
+    /**
+     * fields property.
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'name' => ['type' => 'string', 'null' => true],
+        'position' => ['type' => 'integer', 'null' => true],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'position' => ['type' => 'unique', 'columns' => ['position']],
+        ],
+    ];
+
+    /**
+     * records property.
+     *
+     * @var array
+     */
+    public $records = [
+        ['name' => 'Item A', 'position' => 0],
+        ['name' => 'Item B', 'position' => 1],
+        ['name' => 'Item C', 'position' => 2],
+        ['name' => 'Item D', 'position' => 3],
+        ['name' => 'Item E', 'position' => 4],
+    ];
+}

--- a/tests/TestCase/Model/Behavior/SequenceBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SequenceBehaviorTest.php
@@ -44,12 +44,21 @@ class KeywordItems extends Table
     }
 }
 
+class UniqueItems extends Table
+{
+    public function initialize(array $config)
+    {
+        $this->addBehavior('ADmad/Sequence.Sequence', ['start' => 0]);
+    }
+}
+
 class SequenceTest extends TestCase
 {
     public $fixtures = [
         'plugin.ADmad/Sequence.Items',
         'plugin.ADmad/Sequence.GroupedItems',
         'plugin.ADmad/Sequence.KeywordItems',
+        'plugin.ADmad/Sequence.UniqueItems'
     ];
 
     /**
@@ -241,6 +250,16 @@ class SequenceTest extends TestCase
         $this->assertOrder([1, 2, 4, 5], $GroupedItems, ['group_field' => 1]);
         $this->assertOrder([6, 7, 8, 9, 10], $GroupedItems, ['group_field' => 2]);
         $this->assertOrder([11, 12, 13, 14, 15], $GroupedItems, ['group_field' => 3]);
+
+        $UniqueItems = TableRegistry::get('UniqueItems', [
+            'table' => 'unique_items',
+            'alias' => 'UniqueItems',
+            'className' => 'ADmad\Sequence\Test\TestCase\Model\Behavior\UniqueItems',
+        ]);
+
+        $entity = $UniqueItems->get(3);
+        $UniqueItems->delete($entity);
+        $this->assertOrder([1, 2, 4, 5], $UniqueItems);
     }
 
     /**


### PR DESCRIPTION
Doing this in the beforeDelete breaks in cases where the sequencing is a unique index.