### PR TITLE
Fix bug with null values in scope on edit

### DIFF
--- a/src/Model/Behavior/SequenceBehavior.php
+++ b/src/Model/Behavior/SequenceBehavior.php
@@ -453,6 +453,13 @@ class SequenceBehavior extends Behavior
         $order = $values[$config['sequenceField']];
         unset($values[$config['sequenceField']]);
 
+        foreach ($values as $field => $value) {
+            if (is_null($value)) {
+                $values[$field . ' IS'] = $value;
+                unset($values[$field]);
+            }
+        }
+
         return [$order, $values];
     }
 

--- a/tests/TestCase/Model/Behavior/SequenceBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SequenceBehaviorTest.php
@@ -159,6 +159,14 @@ class SequenceBehaviorTest extends TestCase
         $this->assertOrder([1, 4, 3, 5], $GroupedItems, ['group_field' => 1]);
         $this->assertOrder([6, 2, 7, 8, 17, 9, 10, 16], $GroupedItems, ['group_field IS' => null]);
         $this->assertOrder([11, 12, 13, 14, 15], $GroupedItems, ['group_field' => 3]);
+
+        // Test editing record with scope null
+        $entity = $GroupedItems->get(8);
+        $entity->position = 5;
+        $entity = $GroupedItems->save($entity);
+        $this->assertOrder([1, 4, 3, 5], $GroupedItems, ['group_field' => 1]);
+        $this->assertOrder([6, 2, 7, 17, 9, 8, 10, 16], $GroupedItems, ['group_field IS' => null]);
+        $this->assertOrder([11, 12, 13, 14, 15], $GroupedItems, ['group_field' => 3]);
     }
 
     /**


### PR DESCRIPTION
This PR fix a bug while trying to use null values in scope in edit operation for the behavior. Test method provided.

Reference pr #10 